### PR TITLE
Ton Connect implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ const balance = await provider.getWalletBalance();
 const portfolio = await provider.getFormattedPortfolio(runtime);
 ```
 
+### TonConnect
+
+The `TonConnectWalletProvider` provide Ton Connect protocol to connect to any supported wallets.
+You can use that connection in your code to make transactions or etc.
+
+```typescript
+const walletProvider  = new TonConnectWalletProvider(runtime);
+const wallet = walletProvider.getWalletClient();
+```
+or
+```typescript
+const walletProvider  = new TonConnectWalletProvider(runtime);
+const wallet = walletProvider.getWalletClient(address);
+```
+
 ### TransferAction
 
 The `TransferAction` handles token transfers:

--- a/README.md
+++ b/README.md
@@ -86,11 +86,15 @@ The `TonConnectWalletProvider` provide Ton Connect protocol to connect to any su
 You can use that connection in your code to make transactions or etc.
 
 ```typescript
+import { TonConnectWalletProvider } from "@elizaos/plugin-ton";
+
 const walletProvider  = new TonConnectWalletProvider(runtime);
 const wallet = walletProvider.getWalletClient();
 ```
 or
 ```typescript
+import { TonConnectWalletProvider } from "@elizaos/plugin-ton";
+
 const walletProvider  = new TonConnectWalletProvider(runtime);
 const wallet = walletProvider.getWalletClient(address);
 ```

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
 		"@elizaos/core": "workspace:*",
 		"@ton/crypto": "3.3.0",
 		"@ton/ton": "15.1.0",
+		"@tonconnect/sdk": "^3.0.6",
+		"qrcode": "^1.5.4",
 		"bignumber.js": "9.1.2",
 		"node-cache": "5.1.2",
 		"tsup": "8.3.5"

--- a/src/actions/disconnect.ts
+++ b/src/actions/disconnect.ts
@@ -1,0 +1,82 @@
+import {
+    type Action,
+    type IAgentRuntime,
+    type Memory,
+    type State,
+    type HandlerCallback,
+    elizaLogger,
+} from "@elizaos/core";
+import TonConnect from "@tonconnect/sdk";
+import {IStorage, Storg} from "../utils/storage";
+
+export const disconnect: Action = {
+    name: "DISCONNECT_TON_WALLET",
+    similes: ["DISCONNECT_CONNECTED_TON_WALLET", "REMOVE_TON_CONNECTED"],
+    description:
+        "Disconnect from ton wallet by address",
+
+    validate: async (runtime: IAgentRuntime, _message: Memory) => {
+        const regex = /\b[UV]Q[A-Za-z0-9_-]{46}\b/g;
+        return _message.content.text.match(regex)?.[0] ?? false
+    },
+
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        _state?: State,
+        _options?: { [key: string]: unknown },
+        callback?: HandlerCallback
+    ) => {
+        try {
+            const manifestUrl = runtime.getSetting("TON_CONNECT_MANIFEST_URL") ?? process.env.TON_CONNECT_MANIFEST_URL ?? null
+            if (!manifestUrl) {
+                callback({
+                    text: `Unable to proceed. Please provide a TON_CONNECT_MANIFEST_URL'`,
+                });
+                return;
+            }
+
+                const storage: IStorage = new Storg(runtime.cacheManager)
+
+            const regex = /\b[UV]Q[A-Za-z0-9_-]{46}\b/g;
+            const mentionedAddress = message.content.text.match(regex)?.[0] ?? null;
+
+            if (mentionedAddress) {
+                await storage.readFromCache(mentionedAddress)
+                const connector = new TonConnect({manifestUrl, storage});
+               await connector.restoreConnection()
+                if (connector.connected) {
+                    await connector.disconnect();
+                }
+                await storage.deleteFromCache(mentionedAddress);
+                callback({text: `Address ${mentionedAddress} successfully disconnected`});
+                return
+            }
+
+            callback({text: 'Please provide address to disconnect'});
+
+        } catch (error) {
+            elizaLogger.error("Error in show ton connected action: ", error);
+            callback({
+                text: "An error occurred while make ton connect url. Please try again later.",
+                error
+            });
+            return;
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "user",
+                content: {
+                    text: "let disconnect {{ADDRESS}}",
+                    action: "DISCONNECT_TON_WALLET",
+                },
+            }
+        ],
+
+    ],
+};
+
+export default disconnect;

--- a/src/actions/showConnected.ts
+++ b/src/actions/showConnected.ts
@@ -1,0 +1,67 @@
+import {
+    type Action,
+    type IAgentRuntime,
+    type Memory,
+    type State,
+    type HandlerCallback,
+    elizaLogger,
+} from "@elizaos/core";
+import {IStorage, Storg} from "../utils/storage";
+
+export const showConnected: Action = {
+    name: "SHOW_TON_CONNECTED_WALLETS",
+    similes: ["SHOW_CONNECTED_TON_WALLETS", "LIST_TON_WALLETS", "LIST_TON_CONNECTED_WALLETS"],
+    description:
+        "Use to show all ton connected wallets",
+
+    validate: async (runtime: IAgentRuntime, _message: Memory) => {
+        return true
+    },
+
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        _state?: State,
+        _options?: { [key: string]: unknown },
+        callback?: HandlerCallback
+    ) => {
+        try {
+            const storage: IStorage = new Storg(runtime.cacheManager)
+
+            const connected = await storage.getCachedAddressList()
+
+            let lines = [
+                'Connected wallets:',
+                `────────────────`,
+            ]
+
+            Object.keys(connected).map((address: string) => {
+                lines.push(`- ${address} (${connected[address]})`)
+            });
+
+            callback({text: lines.join("\n")});
+
+        } catch (error) {
+            elizaLogger.error("Error in show ton connected action: ", error);
+            callback({
+                text: "An error occurred while make ton connect url. Please try again later.",
+                error
+            });
+            return;
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "user",
+                content: {
+                    text: "show all ton connected addresses",
+                    action: "SHOW_TON_CONNECTED_WALLETS",
+                },
+            }
+        ],
+
+    ],
+};
+export default showConnected;

--- a/src/actions/tonConnect.ts
+++ b/src/actions/tonConnect.ts
@@ -1,0 +1,131 @@
+import {
+    type Action,
+    type IAgentRuntime,
+    type Memory,
+    type State,
+    type HandlerCallback,
+    elizaLogger,
+} from "@elizaos/core";
+import TonConnect, {
+    isWalletInfoCurrentlyEmbedded,
+    toUserFriendlyAddress,
+    Wallet,
+    WalletInfoCurrentlyEmbedded,
+    WalletInfoRemote
+} from '@tonconnect/sdk';
+import QRCode from 'qrcode';
+import {IStorage, Storg} from "../utils/storage";
+
+export const tonConnect: Action = {
+    name: "TON_CONNECT",
+    similes: ["CONNECT_TON_WALLET", "USE_TON_CONNECT"],
+    description:
+        "Use Ton Connect protocol to connect to your wallet",
+
+    validate: async (runtime: IAgentRuntime, _message: Memory) => {
+        return true;
+    },
+
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        _state?: State,
+        _options?: { [key: string]: unknown },
+        callback?: HandlerCallback
+    ) => {
+        try {
+            const manifestUrl = runtime.getSetting("TON_CONNECT_MANIFEST_URL") ?? process.env.TON_CONNECT_MANIFEST_URL ?? null
+            if (!manifestUrl) {
+                callback({
+                    text: `Unable to proceed. Please provide a TON_CONNECT_MANIFEST_URL'`,
+                });
+                return;
+            }
+
+            const storage: IStorage = new Storg(runtime.cacheManager)
+
+            const connector = new TonConnect({manifestUrl, storage});
+
+            // check if user wrote wallet to use for connect
+            const wallets = await connector.getWallets();
+            const walletNames = wallets.map(wallet => wallet.name.toLowerCase());
+            let mentionedWallet = walletNames.find(walletName => message.content.text.toLowerCase().includes(walletName))
+            const tonKeeper = wallets.find(wallet => wallet.name.toLowerCase() === 'tonkeeper') as WalletInfoRemote;
+
+            let walletConnectionSources: { universalLink: string, bridgeUrl: string } | { jsBridgeKey: string } = {
+                universalLink: tonKeeper.universalLink ?? 'https://app.tonkeeper.com/ton-connect',
+                bridgeUrl: tonKeeper.bridgeUrl ?? 'https://bridge.tonapi.io/bridge'
+            }
+            if (mentionedWallet) {
+                const wallet: WalletInfoRemote = wallets.find(wallet => wallet.name.toLowerCase() === mentionedWallet) as WalletInfoRemote;
+                walletConnectionSources = {
+                    universalLink: wallet.universalLink,
+                    bridgeUrl: wallet.bridgeUrl
+                }
+            } else { // here check embed wallet if not mentioned other
+                const embeddedWallet = wallets.find(isWalletInfoCurrentlyEmbedded) as WalletInfoCurrentlyEmbedded;
+                mentionedWallet = 'Tonkeeper'
+                if (embeddedWallet) {
+                    mentionedWallet = embeddedWallet.name
+                    walletConnectionSources = {jsBridgeKey: embeddedWallet.jsBridgeKey};
+                }
+            }
+
+            const universalLink = connector.connect(walletConnectionSources);
+            const qrcode = await QRCode.toDataURL(universalLink);
+            const text = `You select ${mentionedWallet} to connect. Please open url in browser or scan qrcode to complete connection. ` + universalLink;
+            if (qrcode) {
+                callback({
+                    text,
+                    attachments: [
+                        {
+                            id: crypto.randomUUID(),
+                            url: qrcode,
+                            title: 'Connection url',
+                            source: 'qrcode',
+                            contentType: "image/png",
+                        }
+                    ]
+                });
+            } else {
+                callback({text});
+            }
+
+            connector.onStatusChange(
+                async (data: Wallet) => {
+                    const userFriendlyAddress = toUserFriendlyAddress(data.account.address);
+                    await storage.writeToCache(userFriendlyAddress, data.device.appName)
+                }
+            );
+
+        } catch (error) {
+            elizaLogger.error("Error in ton-connect action: ", error);
+            callback({
+                text: "An error occurred while make ton connect url. Please try again later.",
+                error
+            });
+            return;
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "user",
+                content: {
+                    text: "let connect to ton wallet",
+                    action: "TON_CONNECT",
+                },
+            },
+            {
+                user: "assistant",
+                content: {
+                    text: "Please  use following url to connect to your wallet: ",
+                },
+            },
+        ],
+
+    ],
+};
+
+export default tonConnect;

--- a/src/enviroment.ts
+++ b/src/enviroment.ts
@@ -5,12 +5,14 @@ export const CONFIG_KEYS = {
     TON_PRIVATE_KEY: "TON_PRIVATE_KEY",
     TON_RPC_URL: "TON_RPC_URL",
     TON_RPC_API_KEY: "TON_RPC_API_KEY",
+    TON_CONNECT: "TON_CONNECT",
 };
 
 export const envSchema = z.object({
     TON_PRIVATE_KEY: z.string().min(1, "Ton private key is required"),
     TON_RPC_URL: z.string(),
     TON_RPC_API_KEY: z.string(),
+    TON_CONNECT_MANIFEST_URL: z.string(),
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,19 @@
 import type { Plugin } from "@elizaos/core";
 import transferAction from "./actions/transfer.ts";
 import { WalletProvider, nativeWalletProvider } from "./providers/wallet.ts";
+import tonConnectWalletProvider from "./providers/tonConnect.ts";
+import {tonConnect} from "./actions/tonConnect.ts";
+import {showConnected} from "./actions/showConnected.ts";
+import {disconnect} from "./actions/disconnect.ts";
 
 export { WalletProvider, transferAction as TransferTonToken };
 
 export const tonPlugin: Plugin = {
     name: "ton",
     description: "Ton Plugin for Eliza",
-    actions: [transferAction],
+    actions: [transferAction, tonConnect, showConnected, disconnect],
     evaluators: [],
-    providers: [nativeWalletProvider],
+    providers: [nativeWalletProvider, tonConnectWalletProvider],
 };
 
 export default tonPlugin;

--- a/src/providers/tonConnect.ts
+++ b/src/providers/tonConnect.ts
@@ -1,0 +1,48 @@
+import type {IAgentRuntime, ICacheManager} from "@elizaos/core";
+import TonConnect, {ITonConnect} from "@tonconnect/sdk";
+import {IStorage, Storg} from "../utils/storage.ts";
+
+export class TonConnectWalletProvider {
+    private readonly cacheManager: ICacheManager;
+    private readonly runtime: IAgentRuntime;
+
+    constructor(runtime: IAgentRuntime) {
+        this.runtime = runtime;
+        this.cacheManager = runtime.cacheManager;
+    }
+
+    /**
+     * Get connected via TON Connect wallet provider
+     * @param address - If not provided use first from connected list
+     */
+    async getWalletClient(address: string = null): Promise<ITonConnect> {
+        const storage: IStorage = new Storg(this.cacheManager)
+        const connected: { [key: string]: string } = await storage.getCachedAddressList()
+        let selected: string = Object.keys(connected)?.[0] ?? null;
+        if (address && connected?.[address]) {
+            selected = address
+        }
+
+        if (!selected) {
+            throw new Error('No wallets connected')
+        }
+
+        await storage.readFromCache(selected)
+
+        const manifestUrl = this.runtime.getSetting("TON_CONNECT_MANIFEST_URL") ?? process.env.TON_CONNECT_MANIFEST_URL ?? null
+        if (!manifestUrl) {
+            throw new Error(`Unable to proceed. Please provide a TON_CONNECT_MANIFEST_URL'`);
+        }
+
+        const connector = new TonConnect({manifestUrl, storage});
+        await connector.restoreConnection()
+
+        if (connector.connected) {
+            return connector
+        }
+
+        throw new Error('No wallets connected')
+    }
+}
+
+export default TonConnectWalletProvider;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,100 @@
+import path from "path";
+import {ICacheManager} from "@elizaos/core";
+
+export interface IStorage {
+    setItem(key: string, value: string): Promise<void>;
+
+    getItem(key: string): Promise<string | null>;
+
+    removeItem(key: string): Promise<void>;
+
+    readFromCache(address: string): Promise<any>;
+
+    writeToCache(address: string, wallet: string): Promise<void>;
+
+    deleteFromCache(address: string): Promise<void>;
+
+    getCachedAddressList(): Promise<{ [key: string]: string }>;
+}
+
+/**
+ * Cache and storage manipulating. Partially required for @tonconnect/sdk
+ */
+export class Storg implements IStorage {
+    private storeData: any = {}
+    private cacheManager: ICacheManager
+    private cacheKey = "ton/connect";
+    private listKey = path.join(this.cacheKey, 'list');
+
+    constructor(cacheManager: ICacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    public setItem(key: string, value: string): Promise<void> {
+        this.storeData[key] = value;
+        return Promise.resolve();
+    }
+
+    public getItem(key: string): Promise<string | null> {
+        const value = this.storeData[key];
+        return Promise.resolve(value);
+    }
+
+    public removeItem(key: string): Promise<void> {
+        delete this.storeData[key];
+        return Promise.resolve();
+    }
+
+    /**
+     * Used to load and utilize the selected connection.
+     * @param address
+     */
+    public async readFromCache(address: string): Promise<any> {
+        const data: string = await this.cacheManager.get(
+            path.join(this.cacheKey, address),
+        ) ?? '{}';
+        return JSON.parse(data);
+    }
+
+    /**
+     * Save connected wallet to re-use
+     * @param address
+     * @param wallet
+     */
+    public async writeToCache(address: string, wallet: string): Promise<void> {
+        await this.cacheManager.set(path.join(this.cacheKey, address), JSON.stringify({data: this.storeData, wallet}));
+
+        let list: { [x: string]: string; }
+        try {
+            list = JSON.parse(await this.cacheManager.get(this.listKey) ?? '{}');
+        } catch (error) {
+            list = {}
+        }
+
+        if (!list?.[address]) {
+            list[address] = wallet;
+        }
+
+        await this.cacheManager.set(this.listKey, JSON.stringify(list));
+    }
+
+    /**
+     * To delete connection from list after disconnect
+     * @param address
+     */
+    public async deleteFromCache(address: string): Promise<void> {
+        await this.cacheManager.delete(path.join(this.cacheKey, address));
+
+        let list = JSON.parse(await this.cacheManager.get(this.listKey) ?? '{}');
+        delete list[address];
+        await this.cacheManager.set(this.listKey, JSON.stringify(list));
+    }
+
+    /**
+     * Get all connected wallets by its address
+     */
+    public async getCachedAddressList(): Promise<{ [key: string]: string }> {
+        const list = JSON.parse(await this.cacheManager.get(this.listKey) ?? '{}')
+        return list ?? {}
+    }
+}


### PR DESCRIPTION
# Relates to

[#2984](https://github.com/elizaOS/eliza/issues/2984)

## What does this PR do?

This plugin add support of Ton Connect protocol

## What kind of change is this?

- Plugin allow make connection with all supported ton wallets via Ton Connect protocol
- Make ability to use connectet wallet to make any transaction etc via provider
- Allow multiwallet connection and disconnection
- Can show list connected addresses/wallet
## Detailed testing steps

Ask your character as example
- Let connect ton with Tonkeeper
It show you connection link for tonkeeper and show QRCode to connect from other device

After connection you can ask
- Show me connected wallets
And you get list connected

Now you can disconnect any wallet you need
- Disconnect my wallet UV4fdsof34h....

More over you can use this connection from any place. Just call
```js
import { TonConnectWalletProvider } from "@elizaos/plugin-ton";

const walletProvider  = new WalletProvider(runtime);
const wallet = walletProvider.getWalletClient();
```
or
```js
import { TonConnectWalletProvider } from "@elizaos/plugin-ton";

const walletProvider  = new WalletProvider(runtime);
const wallet = walletProvider.getWalletClient(address);
```
